### PR TITLE
Remove FAQ point about `parametrized`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -644,11 +644,6 @@ Why not use ``@pytest.mark.parametrize``?
     to repeat argument names, and (using ``param``) it supports optional
     keyword arguments.
 
-Why do I get an ``AttributeError: 'function' object has no attribute 'expand'`` with ``@parameterized.expand``?
-    You've likely installed the ``parametrized`` (note the missing *e*)
-    package. Use ``parameterized`` (with the *e*) instead and you'll be all
-    set.
-
 What happened to ``nose-parameterized``?
     Originally only nose was supported. But now everything is supported, and it
     only made sense to change the name!


### PR DESCRIPTION
Hi 👋 `parametrized` was removed today from PyPi by @samupl. Users of `parameterized` shouldn't get those issues any more.

Proof:
![Zrzut ekranu 2023-09-12 o 21 35 01](https://github.com/macieyng/parameterized/assets/82878433/77b2a6a9-9e5f-4c58-a723-d0f5f76f02b8)
